### PR TITLE
Adds basic CMS collections to store resume information

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -103,30 +103,12 @@ collections:
         file: content/pages/index.md
         fields:
           - {label: Header, name: header, string}
-          - name: contribs
-            label: Open Source Contributions
-            widget: object
-            collapsed: false
-            fields:
-              - {label: Repository, name: repo, widget: relation,
-                  collection: repos, search_fields: ['repo'],
-                  display_fields: ['repo'], multiple: true,
-                  value_field: repo}
-          - name: projects
-            label: Open Source Projects
-            widget: object
-            collapsed: false
-            fields:
-              - {label: Repository, name: repo, widget: relation,
-                  collection: repos, search_fields: ['repo'],
-                  display_fields: ['repo'], multiple: true,
-                  value_field: repo}
-          - name: posts
-            label: Blog Posts
-            widget: object
-            collapsed: false
-            fields:
-              - {label: Blog Post, name: post, widget: relation,
-                  collection: posts, search_fields: ['title'],
-                  display_fields: ['title'], multiple: true,
-                  value_field: title}
+          - {label: Open Source Contributions, name: contribs,
+              widget: relation, collection: repos, search_fields: ['repo'],
+              display_fields: ['repo'], multiple: true, value_field: repo}
+          - {label: Open Source Projects, name: projects,
+              widget: relation, collection: repos, search_fields: ['repo'],
+              display_fields: ['repo'], multiple: true, value_field: repo}
+          - {label: Blog Posts, name: posts,
+              widget: relation, collection: posts, search_fields: ['title'],
+              display_fields: ['title'], multiple: true, value_field: title}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: nizar/cms_collections
   squash_merges: true
   commit_messages:
     create: 'Create {{collection}} “{{slug}}”'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: sitedata
+  branch: main
   squash_merges: true
   commit_messages:
     create: 'Create {{collection}} “{{slug}}”'
@@ -11,26 +11,3 @@ backend:
 
 media_folder: static/img
 public_folder: /img
-
-collections:
-  - name: oscontribs
-    label: Open Source Contributions
-    folder: content/opensource/contributions
-    media_folder: /static/img/opensource
-    public_folder: /img/
-    create: true
-    editor:
-      preview: false
-    fields:
-      - {label: Repo, name: repo, widget: string}
-
-  - name: osprojects
-    label: Open Source Projects
-    folder: content/opensource/projects
-    media_folder: /static/img/opensource
-    public_folder: /img/
-    create: true
-    editor:
-      preview: false
-    fields:
-      - {label: Repo, name: repo, widget: string}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -102,35 +102,31 @@ collections:
         label: Landing Page
         file: content/pages/index.md
         fields:
-          - name: sections
-            label: Sections
-            widget: list
-            allow_add: false
+          - {label: Header, name: header, string}
+          - name: contribs
+            label: Open Source Contributions
+            widget: object
+            collapsed: false
             fields:
-              - name: contribs
-                label: Open Source Contributions
-                widget: object
-                collapsed: false
-                fields:
-                  - {label: Repository, name: repo, widget: relation,
-                      collection: repos, search_fields: ['repo'],
-                      display_fields: ['repo'], multiple: true,
-                      value_field: repo}
-              - name: projects
-                label: Open Source Projects
-                widget: object
-                collapsed: false
-                fields:
-                  - {label: Repository, name: repo, widget: relation,
-                      collection: repos, search_fields: ['repo'],
-                      display_fields: ['repo'], multiple: true,
-                      value_field: repo}
-              - name: posts
-                label: Blog Posts
-                widget: object
-                collapsed: false
-                fields:
-                  - {label: Blog Post, name: post, widget: relation,
-                      collection: posts, search_fields: ['title'],
-                      display_fields: ['title'], multiple: true,
-                      value_field: title}
+              - {label: Repository, name: repo, widget: relation,
+                  collection: repos, search_fields: ['repo'],
+                  display_fields: ['repo'], multiple: true,
+                  value_field: repo}
+          - name: projects
+            label: Open Source Projects
+            widget: object
+            collapsed: false
+            fields:
+              - {label: Repository, name: repo, widget: relation,
+                  collection: repos, search_fields: ['repo'],
+                  display_fields: ['repo'], multiple: true,
+                  value_field: repo}
+          - name: posts
+            label: Blog Posts
+            widget: object
+            collapsed: false
+            fields:
+              - {label: Blog Post, name: post, widget: relation,
+                  collection: posts, search_fields: ['title'],
+                  display_fields: ['title'], multiple: true,
+                  value_field: title}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -25,3 +25,17 @@ collections:
     fields:
       - {label: Tool, name: tool, widget: string}
       - {label: Icon, name: icon, widget: image}
+
+  - name: repos
+    label: Repositories
+    folder: content/repos
+    create: true
+    editor:
+      preview: false
+    slug: '{{repo}}'
+    fields:
+      - {label: Repository, name: repo, widget: string}
+      - {label: Link, name: link, widget: string}
+      - {label: Tools, name: tools, widget: relation,
+          collection: tools, searchFields: ['tool'],
+          displayFields: ['tool'], multiple: true}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -63,3 +63,18 @@ collections:
     fields:
       - {label: Employer, name: employer, widget: string}
       - {label: Logo, name: logo, widget: image}
+
+  - name: jobs
+    label: Work Experiences
+    folder: content/jobs
+    create: true
+    editor:
+      preview: false
+    slug: '{{employer}} - {{position}}'
+    fields:
+      - {label: Employer, name: employer, widget: relation,
+          collection: employers, searchFields: ['employer'],
+          displayFields: ['employer'], multiple: true}
+      - {label: Position, name: position, widget: string}
+      - {label: Start, name: start, widget: string}
+      - {label: End, name: end, widget: string}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -50,3 +50,16 @@ collections:
     fields:
       - {label: Title, name: title, widget: string}
       - {label: Link, name: link, widget: string}
+
+  - name: employers
+    label: Employers
+    folder: content/employers
+    media_folder: /static/img/employers
+    public_folder: /img/employers
+    create: true
+    editor:
+        preview: false
+    slug: '{{employer}}'
+    fields:
+      - {label: Employer, name: employer, widget: string}
+      - {label: Logo, name: logo, widget: image}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -11,3 +11,17 @@ backend:
 
 media_folder: static/img
 public_folder: /img
+
+collections:
+  - name: tools
+    label: Tools
+    folder: content/tools
+    media_folder: /static/img/tools
+    public_folder: /img/tools
+    create: true
+    editor:
+      preview: false
+    slug: '{{tool}}'
+    fields:
+      - {label: Tool, name: tool, widget: string}
+      - {label: Icon, name: icon, widget: image}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: nizar/cms_collections
+  branch: main
   squash_merges: true
   commit_messages:
     create: 'Create {{collection}} “{{slug}}”'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -78,3 +78,17 @@ collections:
       - {label: Position, name: position, widget: string}
       - {label: Start, name: start, widget: string}
       - {label: End, name: end, widget: string}
+
+  - name: socials
+    label: Socials
+    folder: content/socials
+    media_folder: /static/img/socials
+    public_folder: /img/socials
+    create: true
+    editor:
+      preview: false
+    slug: '{{name}}'
+    fields:
+      - {label: Name, name: name, widget: string}
+      - {label: Icon, name: icon, widget: image}
+      - {label: Link, name: link, widget: string}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -37,8 +37,9 @@ collections:
       - {label: Repository, name: repo, widget: string}
       - {label: Link, name: link, widget: string}
       - {label: Tools, name: tools, widget: relation,
-          collection: tools, searchFields: ['tool'],
-          displayFields: ['tool'], multiple: true}
+          collection: tools, search_fields: ['tool'],
+          display_fields: ['tool'], multiple: true,
+          value_field: tool}
 
   - name: posts
     label: Blog Posts
@@ -73,8 +74,9 @@ collections:
     slug: '{{employer}} - {{position}}'
     fields:
       - {label: Employer, name: employer, widget: relation,
-          collection: employers, searchFields: ['employer'],
-          displayFields: ['employer'], multiple: true}
+          collection: employers, search_fields: ['employer'],
+          display_fields: ['employer'], multiple: true,
+          value_field: employer}
       - {label: Position, name: position, widget: string}
       - {label: Start, name: start, widget: string}
       - {label: End, name: end, widget: string}
@@ -111,21 +113,24 @@ collections:
                 collapsed: false
                 fields:
                   - {label: Repository, name: repo, widget: relation,
-                      collection: repos, searchFields: ['repo'],
-                      displayFields: ['repo'], multiple: true}
+                      collection: repos, search_fields: ['repo'],
+                      display_fields: ['repo'], multiple: true,
+                      value_field: repo}
               - name: projects
                 label: Open Source Projects
                 widget: object
                 collapsed: false
                 fields:
                   - {label: Repository, name: repo, widget: relation,
-                      collection: repos, searchFields: ['repo'],
-                      displayFields: ['repo'], multiple: true}
+                      collection: repos, search_fields: ['repo'],
+                      display_fields: ['repo'], multiple: true,
+                      value_field: repo}
               - name: posts
                 label: Blog Posts
                 widget: object
                 collapsed: false
                 fields:
                   - {label: Blog Post, name: post, widget: relation,
-                      collection: posts, searchFields: ['title'],
-                      displayFields: ['title'], multiple: true}
+                      collection: posts, search_fields: ['title'],
+                      display_fields: ['title'], multiple: true,
+                      value_field: title}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -92,3 +92,40 @@ collections:
       - {label: Name, name: name, widget: string}
       - {label: Icon, name: icon, widget: image}
       - {label: Link, name: link, widget: string}
+
+  - name: pages
+    label: Pages
+    files:
+      - name: index
+        label: Landing Page
+        file: content/pages/index.md
+        fields:
+          - name: sections
+            label: Sections
+            widget: list
+            allow_add: false
+            fields:
+              - name: contribs
+                label: Open Source Contributions
+                widget: object
+                collapsed: false
+                fields:
+                  - {label: Repository, name: repo, widget: relation,
+                      collection: repos, searchFields: ['repo'],
+                      displayFields: ['repo'], multiple: true}
+              - name: projects
+                label: Open Source Projects
+                widget: object
+                collapsed: false
+                fields:
+                  - {label: Repository, name: repo, widget: relation,
+                      collection: repos, searchFields: ['repo'],
+                      displayFields: ['repo'], multiple: true}
+              - name: posts
+                label: Blog Posts
+                widget: object
+                collapsed: false
+                fields:
+                  - {label: Blog Post, name: post, widget: relation,
+                      collection: posts, searchFields: ['title'],
+                      displayFields: ['title'], multiple: true}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -39,3 +39,14 @@ collections:
       - {label: Tools, name: tools, widget: relation,
           collection: tools, searchFields: ['tool'],
           displayFields: ['tool'], multiple: true}
+
+  - name: posts
+    label: Blog Posts
+    folder: content/posts
+    create: true
+    editor:
+      preview: false
+    slug: '{{title}}'
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: Link, name: link, widget: string}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -14,7 +14,7 @@ public_folder: /img
 
 collections:
   - name: tools
-    label: Tools
+    label: Tool
     folder: content/tools
     media_folder: /static/img/tools
     public_folder: /img/tools
@@ -27,7 +27,7 @@ collections:
       - {label: Icon, name: icon, widget: image}
 
   - name: repos
-    label: Repositories
+    label: Repository
     folder: content/repos
     create: true
     editor:
@@ -42,7 +42,7 @@ collections:
           value_field: tool}
 
   - name: posts
-    label: Blog Posts
+    label: Blog Post
     folder: content/posts
     create: true
     editor:
@@ -53,7 +53,7 @@ collections:
       - {label: Link, name: link, widget: string}
 
   - name: employers
-    label: Employers
+    label: Employer
     folder: content/employers
     media_folder: /static/img/employers
     public_folder: /img/employers
@@ -66,7 +66,7 @@ collections:
       - {label: Logo, name: logo, widget: image}
 
   - name: jobs
-    label: Work Experiences
+    label: Work Experience
     folder: content/jobs
     create: true
     editor:
@@ -82,7 +82,7 @@ collections:
       - {label: End, name: end, widget: string}
 
   - name: socials
-    label: Socials
+    label: Social Link
     folder: content/socials
     media_folder: /static/img/socials
     public_folder: /img/socials


### PR DESCRIPTION
This pull request adds the following:
- CMS Collections based on [nizarmah/resume](github.com/nizarmah/resume)
  - Tools
  - Open Source Repositories
  - Blog Posts
  - Employers
  - Work Experiences
  - Socials
  - Pages:
    - Index page

**Testing instructions**:

Make sure that all the collections added show up in the CMS.

**Author notes and concerns**:

Try adding some information, just please make sure to revert anything added.

**Reviewers**
- [ ] @nizarmah 